### PR TITLE
Refactor/score text view cleanup

### DIFF
--- a/DeCalc/View/RecordTextView.swift
+++ b/DeCalc/View/RecordTextView.swift
@@ -17,16 +17,18 @@ struct RecordTextView: View {
   var onPressTextView: (() -> Void)?
   var scoreFilled: (() -> Void)?
 
-  // TODO: ここロジックやばいから整理
   func getPinIndex(index: Int) -> Int {
     // index: 今もらってきてるindex
-    // 長距離種目の場合
+    // 長距離種目の場合 (1500m: 4'30"50 の形式)
     if isLongRunning {
-      if index > 5 {
+      if index > 4 {
+        // 5番目以降（6,7番目）: 2つの単位記号('と")を飛ばす
         return index - 2
-      } else if index > unitPoint {
+      } else if index > 1 {
+        // 2-4番目（2,3,4番目）: 最初の単位記号(')を飛ばす
         return index - 1
       } else {
+        // 0-1番目: そのまま
         return index
       }
     } else {
@@ -38,13 +40,20 @@ struct RecordTextView: View {
     ZStack(alignment: .center) {
       HStack(alignment: .center) {
         ForEach(isLongRunning ? 0..<numberLength + 3 : 0..<numberLength + 2, id: \.self) { i in
-          if isLongRunning && i == 2 {
+          if isLongRunning && i == 1 {
+            // 1500m: 分記号（'）を1番目の位置に表示
             if let leadingUnit {
               Text(leadingUnit)
                 .font(.system(size: 20, weight: .semibold))
                 .frame(alignment: .bottom)
             }
-          } else if i == unitPoint {
+          } else if isLongRunning && i == 4 {
+            // 1500m: 秒記号（"）を4番目の位置に表示
+            Text(centerUnit)
+              .font(.system(size: 20, weight: .semibold))
+              .frame(alignment: .bottom)
+          } else if !isLongRunning && i == unitPoint {
+            // 他の種目の場合
             Text(centerUnit)
               .font(.system(size: 20, weight: .semibold))
               .frame(alignment: .bottom)

--- a/DeCalc/View/ScoreCalculateView.swift
+++ b/DeCalc/View/ScoreCalculateView.swift
@@ -39,6 +39,7 @@ struct ScoreCalculateView: View {
                   trailingUnit: event.event.trailUnit,
                   unitPoint: event.event.unitPoint,
                   textFieldId: event.id.hashValue,
+                  isLongRunning: event.event.isLongRunning,
                   onPressTextView: {
                     isScoreFocused = switch isScoreFocused {
                     case .focused: nil

--- a/DeCalc/View/ScoreTextView.swift
+++ b/DeCalc/View/ScoreTextView.swift
@@ -12,28 +12,22 @@ import Combine
 struct ScoreTextView: View {
   @Binding var point: Int
   @FocusState.Binding var isFocused: Focus?
-  let maxLength = 4
   var textFieldId: Int
-
-  let numberFormatter: NumberFormatter = {
-      let formatter = NumberFormatter()
-      formatter.numberStyle = .none
-      formatter.zeroSymbol  = ""
-      return formatter
+  
+  private static let numberFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .none
+    formatter.zeroSymbol = ""
+    return formatter
   }()
 
   var body: some View {
-    TextField("0", value: $point, formatter: numberFormatter)
-      .onReceive(Just(point)) { _ in
-        // maxLength桁以降の入力を制限
-//        let hoge = Int(String(point).prefix(maxLength)) ?? 0
-      }
+    TextField("0", value: $point, formatter: Self.numberFormatter)
       .overlay(
         RoundedRectangle(cornerRadius: 6, style: .continuous)
           .stroke(isFocused == .focused(id: textFieldId) ? Color.primaryColor : Color.gray, lineWidth: 2)
       )
       .textFieldStyle(RoundedBorderTextFieldStyle())
-//      .padding()
       .font(.system(size: 20, weight: .bold))
       .focused($isFocused, equals: .focused(id: textFieldId))
       .keyboardType(.numberPad)

--- a/DeCalc/ViewModel/ScoreCalculateViewModel.swift
+++ b/DeCalc/ViewModel/ScoreCalculateViewModel.swift
@@ -98,10 +98,20 @@ extension Event {
     case .Throw: 2
     case .Run(let event):
       switch event {
-        /// 一時的に2にしているが、800m/1500mのみ間に2つ挟まるため単純なIntでは表現できていない
-      case .eightHundredM, .thousandFiveHundredM: 2
+      case .eightHundredM, .thousandFiveHundredM: 2 // 長距離種目では専用ロジックを使用
       case .hundredM, .fourHundredM, .twoHundredM, .hundredMHurdles, .hundredTenMHurdles: 2
       }
+    }
+  }
+  /// 長距離種目かどうか（800m, 1500m）
+  var isLongRunning: Bool {
+    switch self {
+    case .Run(let event):
+      switch event {
+      case .eightHundredM, .thousandFiveHundredM: true
+      default: false
+      }
+    default: false
     }
   }
 }


### PR DESCRIPTION
  ブランチ: refactor/score-text-view-cleanupコミット数: 2つ
  1. refactor: clean up ScoreTextView implementation
  2. fix: implement correct 1500m time display format (M'SS"HH)

  主な変更内容:
  - 1500mの時間表示を4'30"50の正しい形式に修正
  - ScoreTextViewのリファクタリング（パフォーマンス向上とコード整理）
  - 長距離種目（800m, 1500m）専用の表示ロジック実装
  - 他の走種目は従来の⚪︎⚪︎"⚪︎⚪︎フォーマットを維持